### PR TITLE
Reset HudUi on ResetEvent

### DIFF
--- a/src/UnitInfo/core/Main.java
+++ b/src/UnitInfo/core/Main.java
@@ -24,6 +24,11 @@ public class Main extends Mod {
             hud.addWaveTable();
         });
 
+        Events.on(ResetEvent.class, e -> {
+            HudUi hud = new HudUi();
+            hud.addWaveTable();
+        });
+
         Events.run(Trigger.draw, () -> {
             if(Core.settings.getBool("unithealthui"))
                 Groups.unit.each(unit -> new FreeBar().draw(unit));


### PR DESCRIPTION
Resets HudUi on ResetEvent, to avoid it copying itself over itself in the campaign.